### PR TITLE
combine username & repo in the same string

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ The `rsqlserver` package uses the .NET framework SDK to build a small C# project
 You can install it from `github` using the `devtools` package
 
 ```coffee
-require(devtools)
-install_github('rsqlserver', 'agstudy',args='--no-multiarch')
+devtools::install_github('agstudy/rsqlserver', args='--no-multiarch')
 ```
 
 ## Features
@@ -43,7 +42,7 @@ install_github('rsqlserver', 'agstudy',args='--no-multiarch')
 * `dbTransaction`, `dbCommit`, `dbRollback` for **Transaction** management
 * `dbCallProc` (in development)  for **Stored procedure** call.
 * `dbBulkCopy` using **Bulk Copy** for quickly bulk copying Big data.frame or large files into SQL server tables or views.
-* Many DBI extension like `dbGetScalar` , `dbGetNoQuery` , `dbBulkCopy`
+* Many DBI extensions like `dbGetScalar` , `dbGetNoQuery` , `dbBulkCopy`
 * `dbParameter`(coming soon) to handle Transact-SQL named parameters. This will provide better type checking and imporve performance. 
 
 ## Benchmarking


### PR DESCRIPTION
To avoid the error message

> Username parameter is deprecated. Please use agstudy/rsqlserver 

which distracts from the other message

> Github repo contains submodules, may not function as expected!

Plus the cool kids don't use `require()` anymore.  (This post changed my practice  http://yihui.name/en/2014/07/library-vs-require/)
