### PR TITLE
Added dot-dot-dot to write.csv in bulk.copy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rsqlserver
 Type: Package
 Title: SQL Server interface for R
 Version: 1.0
-Date: 2013-10-23
+Date: 2015-05-30
 Author: Amine Gassem (agstudy) <contact@ag-study.com>
 LazyLoad: true
 Maintainer: Amine Gassem (agstudy) <contact@ag-study.com>

--- a/R/DBIConvenience.R
+++ b/R/DBIConvenience.R
@@ -217,7 +217,7 @@ bulk.copy <- function(con,name,value,...){
   if(is.data.frame(value)){
     id = tempfile()                    
     on.exit(unlink(id))
-    write.csv(value,file=id,row.names=FALSE)
+    write.csv(value,file=id,row.names=FALSE,...)
     bulk.copy.file(con,name,id)
   }
 }


### PR DESCRIPTION
So I can add `quote=FALSE`.  Otherwise, the character variables were enclosed in quotes in the eventual database.

I love the bulk copy option uploading pre-cleaned data.  This one table that took 23 *minutes* (with RODBC) now takes 15 *seconds*.  Each batch in our analysis has 10 similar other tables,  This makes quick answers much more feasible.